### PR TITLE
Fix issue reindexing with Null values

### DIFF
--- a/ckanext/repeating/validators.py
+++ b/ckanext/repeating/validators.py
@@ -82,6 +82,8 @@ def repeating_text_output(value):
     """
     if isinstance(value, list):
         return value
+    if value is None:
+        return []
     try:
         return json.loads(value)
     except ValueError:


### PR DESCRIPTION
I had an issue rebuilding the search index with `paster search-index rebuild` when I had Null values in the fields managed by the `repeating_text_output` validator: TypeError: expected string or buffer

I returned an empty list when the value is `None` to fix it.
