### PR TITLE
Fix form blanks

### DIFF
--- a/ckanext/repeating/templates/scheming/form_snippets/repeating_text.html
+++ b/ckanext/repeating/templates/scheming/form_snippets/repeating_text.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 
 {%- set values = data.get(field.field_name, [])
-    + [''] * field.get(form_blanks, 3) -%}
+    + [''] * field.get("form_blanks", 3) -%}
 {%- for element in values -%}
   {{ form.input(
     field.field_name + '-' ~ loop.index,

--- a/ckanext/repeating/templates/scheming/form_snippets/repeating_text.html
+++ b/ckanext/repeating/templates/scheming/form_snippets/repeating_text.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 
 {%- set values = data.get(field.field_name, [])
-    + [''] * field.get("form_blanks", 3) -%}
+    + [''] * field.get('form_blanks', 3) -%}
 {%- for element in values -%}
   {{ form.input(
     field.field_name + '-' ~ loop.index,


### PR DESCRIPTION
There is a typo which prevents the field-property "form_blanks" to be honored. It's always the default 3.
